### PR TITLE
added #save-post on the click handler that saves the blocks

### DIFF
--- a/scripts/snowball-ajax.js
+++ b/scripts/snowball-ajax.js
@@ -1,5 +1,5 @@
 jQuery(document).ready(function($) {
-  $("#publish").click(function() {
+  $("#publish, #save-post").click(function() {
     var blocksRetrieved = retrieveBlocks();
     var articleRetrieved = retrieveRenderedPage();
 


### PR DESCRIPTION
Clicking the save draft or save as pending button doesn't save the blocks. So I added $("#publish, #save-post") on to the click handler so it now saves.
