### PR TITLE
Are roles even real?

### DIFF
--- a/inc/snowball-config.php
+++ b/inc/snowball-config.php
@@ -58,27 +58,35 @@ register_deactivation_hook($path . 'snowball.php', 'snowball_rewrite_flush_deact
 
 function snowball_add_caps() {
   $role = get_role('administrator');
-  $role->add_cap('snowball_edit_posts');
-  $role->add_cap('snowball_delete_posts');
-  $role->add_cap('snowball_edit_others_posts');
-  $role->add_cap('snowball_publish_posts');
-  $role->add_cap('snowball_read_private_posts');
+  if ( $role ) {
+    $role->add_cap('snowball_edit_posts');
+    $role->add_cap('snowball_delete_posts');
+    $role->add_cap('snowball_edit_others_posts');
+    $role->add_cap('snowball_publish_posts');
+    $role->add_cap('snowball_read_private_posts');
+  }
 
   $role = get_role('editor');
-  $role->add_cap('snowball_edit_posts');
-  $role->add_cap('snowball_delete_posts');
-  $role->add_cap('snowball_edit_others_posts');
-  $role->add_cap('snowball_publish_posts');
-  $role->add_cap('snowball_read_private_posts');
+  if ( $role ) {
+    $role->add_cap('snowball_edit_posts');
+    $role->add_cap('snowball_delete_posts');
+    $role->add_cap('snowball_edit_others_posts');
+    $role->add_cap('snowball_publish_posts');
+    $role->add_cap('snowball_read_private_posts');
+  }
 
   $role = get_role('author');
-  $role->add_cap('snowball_edit_posts');
-  $role->add_cap('snowball_delete_posts');
-  $role->add_cap('snowball_publish_posts');
+  if ( $role ) {
+    $role->add_cap('snowball_edit_posts');
+    $role->add_cap('snowball_delete_posts');
+    $role->add_cap('snowball_publish_posts');
+  }
 
   $role = get_role('contributor');
-  $role->add_cap('snowball_edit_posts');
-  $role->add_cap('snowball_delete_posts');
+  if ( $role ) {
+    $role->add_cap('snowball_edit_posts');
+    $role->add_cap('snowball_delete_posts');
+  }
 }
 add_action('admin_init', 'snowball_add_caps');
 


### PR DESCRIPTION
First, I'm incredibly dumb for not catching that. Second, this is all in the name of The Triangle.

We run Members on our site: https://wordpress.org/plugins/members/. Awesome plugin, but the plugin does have the ability to rename and delete the default roles. I created a special set of roles that are more specific to our needs, but of course snowball blows up when it can't find a role that it's been asked to query.

I think this is the best solution going forward. If people are using members on their site, then snowball isn't going to work, so it might be best to just document the roles and capabilities so that people using snowball who might not have any of the default roles installed can add them manually. Until they do, they won't be able to access snowball, but I think that's what we (and the other Members users) get for messing with the defaults.

The alternative is a fatal crash, because without checking first, its assumed that all those roles exist.

Feel free to merge. :smile: 
